### PR TITLE
Add development branch as trigger to Github workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,9 +3,13 @@ name: Android CI
 
 on:
   push:
-    branches: [ main ]
+    branches: 
+      - main
+      - development
   pull_request:
-    branches: [ main ]
+    branches: 
+      - main
+      - development
 
 jobs:
   build:


### PR DESCRIPTION
Added the development branch to Github workflows so that SonarCloud will be activated when something is pushed to development.